### PR TITLE
Smart-1 Cloud Support

### DIFF
--- a/APIFiles/APIClient.go
+++ b/APIFiles/APIClient.go
@@ -49,6 +49,7 @@ type ApiClient struct {
 	fingerprint             string
 	sid                     string
 	server                  string
+	cloud_path				string	
 	domain                  string
 	proxyHost               string
 	proxyPort               int
@@ -101,6 +102,7 @@ func APIClient(apiCA ApiClientArgs) *ApiClient {
 		fingerprint:             apiCA.Fingerprint,
 		sid:                     apiCA.Sid,
 		server:                  apiCA.Server,
+		cloud_path:				 apiCA.Cloud_path, 		
 		domain:                  "",
 		proxyHost:               apiCA.ProxyHost,
 		proxyPort:               apiCA.ProxyPort,
@@ -126,6 +128,11 @@ func (c *ApiClient) GetPort() int {
 // Returns the context of API client
 func (c *ApiClient) GetContext() string {
 	return c.context
+}
+
+// Returns the Cloud Path of API client
+func (c *ApiClient) GetCloud_path() string {
+	return c.cloud_path
 }
 
 func (c *ApiClient) GetAutoPublish() bool {
@@ -331,8 +338,16 @@ func (c *ApiClient) ApiCall(command string, payload map[string]interface{}, sid 
 		}
 	}
 
+// Update URL string tO include cloud_path
+
 	var url string
-	if c.apiVersion == "" {
+	if c.cloud_path != "" {
+		if c.apiVersion == "" {
+		url = "/" + c.cloud_path + "/" + c.context + "/" + command
+		}else {
+		url = "/" + c.cloud_path + "/" + c.context + "/" + "v" + c.apiVersion + "/" + command
+		}
+	}else if c.apiVersion == "" {
 		url = "/" + c.context + "/" + command
 	} else {
 		url = "/" + c.context + "/" + "v" + c.apiVersion + "/" + command

--- a/APIFiles/APIClientArgs.go
+++ b/APIFiles/APIClientArgs.go
@@ -8,6 +8,7 @@ type ApiClientArgs struct {
 	Fingerprint             string
 	Sid                     string
 	Server                  string
+	Cloud_path				string
 	HttpDebugLevel          string
 	ProxyHost               string
 	ProxyPort               int
@@ -30,6 +31,7 @@ Port: the port that is being used
 Fingerprint: server's fingerprint
 Sid: session id
 Server: server's ip
+Cloud_path: The additional server path required when using Checkpoint Smart-1 Cloud management
 ProxyHost: proxy's ip
 ProxyPort: proxy port
 ApiVersion: the version of the api
@@ -46,6 +48,7 @@ func APIClientArgs(port int, fingerprint string, sid string, server string, prox
 		Fingerprint: fingerprint,
 		Sid: sid,
 		Server: server,
+		Cloud_path: cloud_path,
 		ProxyHost: proxyHost,
 		ProxyPort: proxyPort,
 		ApiVersion: apiVersion,


### PR DESCRIPTION
Add cloud_path to allow to API connections the Checkpoint Smart-1 Cloud

Smart-1 Cloud requires and additional path for API requests

https://_tennant_.maas.checkpoint.com/_cloud-path_/web_api/login

This change adds in as an optional parameter